### PR TITLE
Returns a list of available factories

### DIFF
--- a/app/controllers/remote_factory_girl_home_rails/home_controller.rb
+++ b/app/controllers/remote_factory_girl_home_rails/home_controller.rb
@@ -13,6 +13,11 @@ module RemoteFactoryGirlHomeRails
       end
     end
 
+    def index
+      factories = FactoryGirl.factories.map(&:name)
+      render json: { factories: factories }
+    end
+
     private
 
     def factory(params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 RemoteFactoryGirlHomeRails::Engine.routes.draw do
-  resources :home, only: [:create]
+  resources :home, only: [:create, :index]
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -4,6 +4,13 @@ class FactoryGirl
   def self.create(factory, opts = {})
     true
   end
+
+  def self.factories
+    [
+      OpenStruct.new('name' => 'Sam'),
+      OpenStruct.new('name' => 'Pete')
+    ]
+  end
 end
 
 describe RemoteFactoryGirlHomeRails::HomeController do
@@ -36,6 +43,16 @@ describe RemoteFactoryGirlHomeRails::HomeController do
     it 'should return status code 403 when RemoteFactoryGirlHomeRails is not enabled' do
       post :create, {}
       expect(response.status).to eq(403)
+    end
+  end
+
+  describe '#index' do
+
+    before { RemoteFactoryGirlHomeRails.enable! }
+
+    it 'should return a list of available factories' do
+      get :index
+      expect(response.body).to eq('{"factories":["Sam","Pete"]}')
     end
   end
 end


### PR DESCRIPTION
Adds ability to retrieve a list of factories available in _home_.
This is particularly useful when the client developer does not have access to
_home_'s source code and can not search for available factories themselves
(i.e. a mobile application developer perhaps).
