### PR TITLE
Bump Rails support to 4.1

### DIFF
--- a/remote_factory_girl_home_rails.gemspec
+++ b/remote_factory_girl_home_rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", "~> 4.0.2"
+  s.add_dependency "rails", ">= 4.0.2", "<= 4.1.5"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
Preferably we could just set the Rails version to "~> 4", any reason for 4.0.2 specifically instead of just "~> 4.0"? 
