### PR TITLE
Support multiple versions of rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: ruby
+gemfile:
+  - gemfiles/rails_32.gemfile
+  - gemfiles/rails_40.gemfile
+  - gemfiles/rails_41.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ gemfile:
   - gemfiles/rails_32.gemfile
   - gemfiles/rails_40.gemfile
   - gemfiles/rails_41.gemfile
+before_script:
+  - bundle exec rake db:migrate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RemoteFactoryGirlHomeRails
+[![Build Status](https://travis-ci.org/tdouce/remote_factory_girl_home_rails.svg)](https://travis-ci.org/tdouce/remote_factory_girl_home_rails)
 
 [factory_girl](https://github.com/thoughtbot/factory_girl) for [Service Oriented Architecture](http://en.wikipedia.org/wiki/Service-oriented_architecture) (SOA). Create test data with [factory_girl](https://github.com/thoughtbot/factory_girl) remotely when used in conjunction with [remote_factory_girl](https://github.com/tdouce/remote_factory_girl).
 

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'rails', '~> 3.2.0'

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.0.0'

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.1.0'

--- a/remote_factory_girl_home_rails.gemspec
+++ b/remote_factory_girl_home_rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", "~> 4.0.2"
+  s.add_dependency "rails", ">= 3.2.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency 'rspec-rails'

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -10,3 +10,6 @@
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
 Dummy::Application.config.secret_key_base = '306ef23b12378c8010edf06c95aae6696adf731c29efb81a6cec4a02be512c1a112c513075672eb3ed46a35ac61e99c56dc7a059557512b02bae46e08f5cb1de'
+
+# NOTE: for Rails 3.2
+Dummy::Application.config.secret_token = '0' * 30

--- a/spec/models/remote_factory_girl_home_rails_spec.rb
+++ b/spec/models/remote_factory_girl_home_rails_spec.rb
@@ -5,13 +5,13 @@ describe RemoteFactoryGirlHomeRails do
   describe '.enable!' do
     it 'should return true when enabled' do
       RemoteFactoryGirlHomeRails.enable!
-      expect(RemoteFactoryGirlHomeRails.enabled?).to be_true
+      expect(RemoteFactoryGirlHomeRails.enabled?).to be true
     end
   end
 
   describe '.enabled?' do
     it 'should return false when disabled' do
-      expect(RemoteFactoryGirlHomeRails.enabled?).to be_false
+      expect(RemoteFactoryGirlHomeRails.enabled?).to be false
     end
   end
 
@@ -19,7 +19,7 @@ describe RemoteFactoryGirlHomeRails do
     it 'should disable' do
       RemoteFactoryGirlHomeRails.enable!
       RemoteFactoryGirlHomeRails.disable!
-      expect(RemoteFactoryGirlHomeRails.enabled?).to be_false
+      expect(RemoteFactoryGirlHomeRails.enabled?).to be false
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
+  config.infer_spec_type_from_file_location!
   config.include RSpec::Rails::RequestExampleGroup, type: :feature
 
   config.before(:each) do


### PR DESCRIPTION
I want to use this gem in Rails 3.2 and 4.1 application.

I add config for travis-ci to test against multiple versions of rails, for 3.2, 4.0, 4.1 and change gemspec rails version :star: 

Could you please setup travis-ci for remote_factory_girl_home_rails :question: 
