### PR TITLE
Serialize newly created models with #to_json...

### DIFF
--- a/app/controllers/remote_factory_girl_home_rails/home_controller.rb
+++ b/app/controllers/remote_factory_girl_home_rails/home_controller.rb
@@ -5,8 +5,8 @@ module RemoteFactoryGirlHomeRails
     
     def create 
       if RemoteFactoryGirlHomeRails.enabled?
-        factory = FactoryGirl.create(factory(params), attributes(params))
-        render json: factory
+        model = FactoryGirl.create(factory(params), attributes(params))
+        render json: model.to_json
       else
         forbidden = 403
         render json: { status: forbidden }, status: forbidden 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -26,7 +26,8 @@ describe RemoteFactoryGirlHomeRails::HomeController do
     end
 
     describe 'when enabled' do
-
+      let(:user) { double("instance of User model") }
+      let(:user_json) { { "user" => "whatever" }.to_json }
       before { RemoteFactoryGirlHomeRails.enable! }
 
       it 'should return status code 200' do
@@ -37,6 +38,13 @@ describe RemoteFactoryGirlHomeRails::HomeController do
       it 'should create a factory' do
         expect(FactoryGirl).to receive(:create).with(:user, {})
         post :create, {'factory' => 'user'}
+      end
+
+      it "should serialize the new User model with #to_json" do
+        expect(FactoryGirl).to receive(:create).with(any_args).and_return(user)
+        expect(user).to receive(:to_json).and_return(user_json)
+        post :create, "factory" => "user"
+        expect(response.body).to eql(user_json)
       end
     end
 


### PR DESCRIPTION
... in order to avoid interference from other gems such as [active_model_serializers](https://github.com/rails-api/active_model_serializers).
