### PR TITLE
Relax Rails dependency requirement

### DIFF
--- a/remote_factory_girl_home_rails.gemspec
+++ b/remote_factory_girl_home_rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", "~> 4.0.2"
+  s.add_dependency "rails", "~> 4.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
Currently I'm unable to this gem because my project uses Rails 4.2
Since the Rails project uses semantic versioning, I believe there are no reasons for the current version constraint.
